### PR TITLE
Feature/expire old topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Discohands is configured through environment variables, or by a
    `development`.
  - `SESSION_SECRET`: Secret key for stored sessions. Default "keyboard
    cat".
+ - `MAXIMUM_TOPIC_AGE_DAYS`: Optional number of days after which a topic is omitted. Default is no omission due to topic age.   
  - `REDIS_URL` or `REDISCLOUD_URL`: Redis connection URL. Default
    `redis://localhost:6379`.
  - `MONGODB_URI` or `MONGOLAB_URI`: MongoDB connection URI. Default

--- a/models/topic-filters.js
+++ b/models/topic-filters.js
@@ -1,0 +1,27 @@
+const moment = require("moment");
+
+function IdentityFilter() {
+    return function identityFilter(where) {
+        return where;
+    }
+}
+
+function OmitStaleFilter(max_age) {
+    return function omitStaleFilter(where) {
+        const threshold = moment().subtract(max_age, "days");
+
+        return Object.assign({ date: { $gte: threshold.toDate() } }, where);
+    }
+}
+
+function FilterFactory() {
+    const MAXIMUM_TOPIC_AGE_DAYS = parseInt(process.env.MAXIMUM_TOPIC_AGE_DAYS, 10);
+
+    if (MAXIMUM_TOPIC_AGE_DAYS > 0) {
+        return OmitStaleFilter(MAXIMUM_TOPIC_AGE_DAYS);
+    }
+
+    return IdentityFilter();
+}
+
+module.exports = FilterFactory;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discohands",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Democratically choose topics to discuss",
   "main": "app.js",
   "scripts": {

--- a/routes/topics.js
+++ b/routes/topics.js
@@ -1,6 +1,8 @@
 var express = require('express');
 
 var Topic = require('../models/topic');
+var TopicFilterFactory = require('../models/topic-filters');
+var topicFilter = TopicFilterFactory();
 
 var router = express.Router();
 var MINIMUM_VOTES = parseInt(process.env.MINIMUM_VOTES, 10);
@@ -9,7 +11,7 @@ function getTopics(req, res, next) {
   var page = +req.params.page || 1;
 
   Topic.getPage({
-    where: { discussed: false },
+    where: topicFilter({ discussed: false }),
     sort: '-score date',
     limit: 10,
     page: page


### PR DESCRIPTION
Filter out topics older than a configurable value to avoid presenting old topics for voting.

Fixes #20 

# Before

![image](https://user-images.githubusercontent.com/1574577/73782689-83175b80-4760-11ea-9d94-6bd690e69f0b.png)

# After

![image](https://user-images.githubusercontent.com/1574577/73782808-ad691900-4760-11ea-93a8-b95c72c1b5a5.png)
